### PR TITLE
Point readme links to this fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Catapult** is a cross-platform launcher and content manager for [Cataclysm: Dark Days Ahead](https://github.com/CleverRaven/Cataclysm-DDA) and [Cataclysm: Bright Nights](https://github.com/cataclysmbnteam/Cataclysm-BN). It is in part inspired by earlier versions of [Rémy Roy's launcher](https://github.com/remyroy/CDDA-Game-Launcher).
 
-[**Download latest release**](https://github.com/qrrk/Catapult/releases/latest)  |  [**See all releases**](https://github.com/qrrk/Catapult/releases)
+[**Download latest release**](https://github.com/AriaMoradi/Catapult/releases/latest)  |  [**See all releases**](https://github.com/AriaMoradi/Catapult/releases)
 
 
 
@@ -23,7 +23,7 @@
 
 ## Installation
 
-None required. The launcher is a single, self-contained executable. Just [download](https://github.com/qrrk/Catapult/releases/latest) it to a separate folder and run.
+None required. The launcher is a single, self-contained executable. Just [download](https://github.com/AriaMoradi/Catapult/releases/latest) it to a separate folder and run.
 
 
 ### Linux


### PR DESCRIPTION
As they're download links, figured they should point here.

The other references to `github.com/qrrk` in the app itself are all for reporting bugs, figured that change is out of scope of this one.