### PR TITLE
Fix Fetching Warning for EOD and TISH

### DIFF
--- a/text/en/release_manager.csv
+++ b/text/en/release_manager.csv
@@ -6,6 +6,6 @@
 "msg_got_n_releases","Got %s releases."
 "msg_fetching_releases_dda","Fetching releases for DDA Experimental..."
 "msg_fetching_releases_bn","Fetching releases for BN Experimental..."
-"msg_fetching_releases_dda","Fetching releases for DDA Experimental..."
-"msg_fetching_releases_bn","Fetching releases for BN Experimental..."
+"msg_fetching_releases_eod","Fetching releases for EOD Experimental..."
+"msg_fetching_releases_tish","Fetching releases for TISH Experimental..."
 "msg_invalid_fetch_func_param","ReleaseManager.fetch() was passed %s"


### PR DESCRIPTION
The fetching message for the two newer forks were mislabeled as DDA and BN, just changed it to the appropriate forks and exported the executable file, all seemed to work fine.

![bug1](https://github.com/AriaMoradi/Catapult/assets/20976050/ce36fc64-c0ea-4725-98f5-6c9379d1a167)
![Capturar](https://github.com/AriaMoradi/Catapult/assets/20976050/b4a25d66-8c97-43d5-86af-222f49aca343)
